### PR TITLE
update readme + add requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ PHP2PY_COMPAT=$HOME/php_compat.py python3 index.py
 
 There are a few things left to finish in order to get a complete working converting without having to edit to converted code. I was waiting to tackle those before publishing the code but I'm not having much spare time left these days.
 
-Any PR's and/or comments are more than welcome.
+Any PRs and/or comments are more than welcome.
 
 Roadmap
 -------

--- a/README.md
+++ b/README.md
@@ -6,13 +6,23 @@ Convert PHP code to Python running under CGI (beta).
 Requirements
 ------------
 
-- PHP 7 with Package PHP-Parser installed (https://github.com/nikic/PHP-Parser#quick-start)
-- Python 3 with Package goto-statement installed and the MySQL connector:
-  https://pypi.org/project/goto-statement/
-  https://pypi.org/project/mysql-connector-python/
+- PHP 7
+- Python 3
+- Pip https://pypi.org/project/pip/
+- Composer https://getcomposer.org/
+
+Install dependencies
+------------
 
 ```
-$ python3 -m pip install goto-statement mysql-connector-python
+$ php composer.phar install
+$ python3 -m pip install -r requirements.txt
+```
+
+If you have composer / pip installed globally:
+```
+$ composer install
+$ pip3 install -r requirements.txt
 ```
 
 
@@ -42,7 +52,7 @@ Roadmap
 -------
 
 - [x] Complete implementation of AST nodes transformation.
-- [x] Address limitations of Python language 
+- [x] Address limitations of Python language
 - [ ] Finish implementing all of the supporting PHP functions to run WordPress.
 - [ ] Rearrange AST nodes to simplify conversion.
 - [ ] Refactor converted code to output Flask/Django code instead. Requires an overhaul of the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+goto-statement
+mysql-connector-python
+packaging


### PR DESCRIPTION
* readme: easier dependencies installation
* requirements.txt for pip
* add packaging as dependency for python

I think it's not important which dependencies are necessary. Instead, it should be easy to install.